### PR TITLE
プロフィールページからトップに戻る際のスクロールを追加

### DIFF
--- a/app/profile/[id]/page.tsx
+++ b/app/profile/[id]/page.tsx
@@ -26,6 +26,17 @@ export default function ProfileDetail() {
   const [hasLiked, setHasLiked] = useState(false)
   const [isLiking, setIsLiking] = useState(false)
 
+  // ブラウザの「戻る」で一覧に戻った時も、該当ユーザー位置へ復元するための目印を保存
+  useEffect(() => {
+    const id = params?.id
+    if (!id) return
+    try {
+      sessionStorage.setItem('homeFocus', String(id))
+    } catch {
+      // ignore
+    }
+  }, [params?.id])
+
   useEffect(() => {
     async function fetchData() {
       const { data: profileData, error: profileError } = await supabase
@@ -228,7 +239,7 @@ export default function ProfileDetail() {
       <div className="bg-gradient-to-r from-primary to-secondary h-48"></div>
 
       <div className="max-w-4xl mx-auto px-4 -mt-32">
-        <Link href="/" className="inline-flex items-center gap-1 text-white hover:underline mb-6">
+        <Link href={`/?focus=${profile.id}`} className="inline-flex items-center gap-1 text-white hover:underline mb-6">
           <ArrowLeft size={18} />
           <span>一覧に戻る</span>
         </Link>

--- a/components/ProfileCard.tsx
+++ b/components/ProfileCard.tsx
@@ -8,7 +8,11 @@ type Props = {
 
 export default function ProfileCard({ profile }: Props) {
   return (
-    <Link href={`/profile/${profile.id}`}>
+    <Link
+      href={`/profile/${profile.id}`}
+      id={`profile-${profile.id}`}
+      className="block scroll-mt-28"
+    >
       <div className="group bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300 cursor-pointer">
         <div className="aspect-[4/3] bg-cream overflow-hidden">
           {profile.photo_url ? (


### PR DESCRIPTION
## 概要
- ブラウザの戻るボタンでも一覧で同じユーザー位置に戻れるように、以下を追加
　-詳細ページ `app/profile/[id]/page.tsx`
　- そのプロフィールを開いた時点で sessionStorage.homeFocus = <id> を保存
　- 一覧ページ `app/page.tsx`
　※ `?focus=` が無い場合でも `sessionStorage.homeFocus` を見てスクロールし、スクロール成功後に `homeFocus` を削除

## 動作確認
- Slackに動画あげてます。

```bash
git fetch
git checkout fix/10-profile-back-navigation
npm run dev
```